### PR TITLE
Readme and linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .vscode
 .mypy_cache
 __pycache__
-ngrams
+ngrams/*.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# sonnet-generator
+
+See slides at https://slides.com/janiceshiu/pycon-shakespeare-sonnets-python
+
+To setup:
+
+First install dependencies:
+
+```
+pip install -r requirements.txt
+```
+
+Then, make sure you have the dataset downloaded:
+
+```
+$ python
+>>> import nltk
+>>> nltk.download('gutenberg')
+True
+>>> nltk.download('brown')
+True
+```

--- a/poem_complete.py
+++ b/poem_complete.py
@@ -12,6 +12,7 @@ import time
 import pickle
 import json
 import re
+import platform
 from subprocess import call
 
 # random.seed(1)
@@ -118,7 +119,8 @@ def main():
 
 
 def say(line:str):
-    call(["say", line])
+    if platform.system() == 'Darwin':
+        call(["say", line])
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ jupyter==1.0.0
 jupyter-client==5.2.3
 jupyter-console==5.2.0
 jupyter-core==4.4.0
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 mistune==0.8.3
 nbconvert==5.3.1
 nbformat==4.4.0


### PR DESCRIPTION
- Only runs `say` on Mac
- Adds a README
- Makes sure `ngrams` directory is committed, so you don't have to create it.
- Dependency update for MarkupSafe, so it works on latest python (I tested on 3.8.5)